### PR TITLE
Change private key default length

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,4 @@
-# This GitHub action runs your tests for each commit push and/or PR. Optionally
-# you can turn it on using a cron schedule for regular testing.
-#
-name: Tests
+name: CI Tests
 on:
   pull_request:
     paths-ignore:
@@ -9,14 +6,8 @@ on:
   push:
     paths-ignore:
       - "README.md"
-  # For systems with an upstream API that could drift unexpectedly (like most SaaS systems, etc.),
-  # we recommend testing at a regular interval not necessarily tied to code changes. This will
-  # ensure you are alerted to something breaking due to an API change, even if the code did not
-  # change.
-  # schedule:
-  #   - cron: '0 13 * * *'
+
 jobs:
-  # ensure the code builds...
   build:
     name: Build
     runs-on: ubuntu-latest
@@ -25,57 +16,61 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2.1.3
         with:
-          go-version: "1.16"
-        id: go
+          go-version: "1.17"
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2.3.4
 
       - name: Get dependencies
-        run: |
-          go mod download
+        run: go mod download
 
       - name: Build
-        run: |
-          go build -v .
-
-  # run acceptance tests in a matrix with Terraform core versions
-  test:
-    name: Matrix Test
-    needs: build
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    strategy:
-      fail-fast: false
-      matrix:
-        # list whatever Terraform versions here you would like to support
-        terraform:
-          - "0.15"
-          - "1.0"
-    steps:
-      - name: Set up Go
-        uses: actions/setup-go@v2.1.3
-        with:
-          go-version: "1.16"
-        id: go
-
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v2.3.4
-
-      - name: Get dependencies
-        run: |
-          go mod download
+        run: go build -v .
 
       - name: TF acceptance tests
         timeout-minutes: 10
+        run: go test -v -cover ./internal/provider/
         env:
           TF_ACC: "1"
-          TF_ACC_TERRAFORM_VERSION: ${{ matrix.terraform }}
 
-          # Set whatever additional acceptance test env vars here. You can
-          # optionally use data from your repository secrets using the
-          # following syntax:
-          # SOME_VAR: ${{ secrets.SOME_VAR }}
+  # run acceptance tests in a matrix with Terraform core versions
+  # test:
+  #   name: Matrix Test
+  #   needs: build
+  #   runs-on: ubuntu-latest
+  #   timeout-minutes: 15
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       terraform:
+  #         - "0.15"
+  #         - "1.0"
+  #   steps:
+  #     - name: Set up Go
+  #       uses: actions/setup-go@v2.1.3
+  #       with:
+  #         go-version: "1.17"
+  #       id: go
 
-        run: |
-          go test -v -cover ./internal/provider/
+  #     - uses: hashicorp/setup-terraform@v1
+  #       with:
+  #         terraform_version: ${{ matrix.terraform }}
+
+  #     - run: terraform --version
+
+  #     - name: Check out code into the Go module directory
+  #       uses: actions/checkout@v2
+
+  #     - name: Get dependencies
+  #       run: go mod download
+
+  #     - name: TF acceptance tests
+  #       timeout-minutes: 10
+  #       env:
+  #         TF_ACC: "1"
+  #         # Set whatever additional acceptance test env vars here. You can
+  #         # optionally use data from your repository secrets using the
+  #         # following syntax:
+  #         # SOME_VAR: ${{ secrets.SOME_VAR }}
+
+  #       run: go test -v -cover ./internal/provider/

--- a/internal/provider/resource_private_key.go
+++ b/internal/provider/resource_private_key.go
@@ -44,7 +44,7 @@ func resourcePrivateKey() *schema.Resource {
 				Optional:    true,
 				Description: "Number of bits to use when generating RSA key.",
 				ForceNew:    true,
-				Default:     4096,
+				Default:     2048,
 			},
 
 			"private_key": {


### PR DESCRIPTION
- Bump go version and limit tests to Terraform version provided by CI 
- Changed default private key length to a more sensible default
