### PR TITLE
Add support for darwin_arm64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2.7.0
         with:
-          version: latest
+          version: v1.5.0
           args: release --rm-dist
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}


### PR DESCRIPTION
Opened an issue couple of days ago #25 

The go-releaser action version parameter was set to latest but I don't think it was actually using v1.5.0 since [v0.157.0](https://goreleaser.com/deprecations/) has added support for this combo